### PR TITLE
Fix rooms not dropped after use (fixes #12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "ws-hotel"
 version = "0.1.0"
-source = "git+https://github.com/edgarogh/ws-hotel?branch=early-dev#ea6bb8a9f29af5245c24da4772c1b38fd69aefcf"
+source = "git+https://github.com/edgarogh/ws-hotel?branch=early-dev#eef76ec951115b35544c66b54556188ff1049382"
 dependencies = [
  "ws",
 ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,10 @@ enum ClientEventGame {
     StartRound,
     /// When Client answers to a question
     Answer { vote: Vote },
+
+    /// Sent by a client who wants to leave its current game room. May be sent at any point in time,
+    /// but, as of today, a normal client should only display a "leave" button at the end of a game.
+    LeaveRoom,
 }
 
 impl From<&ServerEvent<'_>> for Message {
@@ -318,6 +322,9 @@ impl RoomHandler for GameRoom {
                 cx.broadcast(&res)?;
 
                 Ok(None)
+            }
+            ClientEventGame::LeaveRoom => {
+                Ok(Some(Relocation::new(&self.lobby, ())))
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ enum ClientEventLobby {
         username: Username,
         avatar: String,
         code: Option<String>,
+        // TODO règles (replace this enum field with another enum)
     },
 }
 

--- a/static/main.js
+++ b/static/main.js
@@ -154,20 +154,11 @@ const registerSocketMessages = (socket) => socket.addEventListener('message', ev
                 localStorage.removeItem(LOCALSTORAGE_CURRENT_GAME_CODE)
             }
             break
-        case 'RoomCreated':
+        case 'OnRoomJoin':
             game = data.code
-            name = document.getElementById('username').value
             localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_CODE, game)
             localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_USERNAME, name)
             localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_AVATAR, avatar)
-            send({
-                tag: 'JoinRoom',
-                username: name,
-                avatar: avatar,
-                code: game
-            })
-            break
-        case 'OnRoomJoin':
             players = data.players
             questionCounter = data.question_counter
             m.route.set('/lobby')
@@ -306,7 +297,10 @@ const Home = {
                 m('a', { className: 'button', onclick: () => {
                     name = document.getElementById('username').value
                     send({
-                        tag: 'CreateRoom'
+                        tag: 'JoinRoom',
+                        avatar: avatar,
+                        username: name,
+                        code: null
                     })
                 } }, 'Créer une partie')
             ]),
@@ -317,9 +311,6 @@ const Home = {
                 m('a', { className: 'button', href: '#', onclick: () => {
                     game = document.getElementById('code').value
                     name = document.getElementById('username').value
-                    localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_CODE, game)
-                    localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_USERNAME, name)
-                    localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_AVATAR, avatar)
                     send({
                         tag: 'JoinRoom',
                         avatar: avatar,

--- a/static/main.js
+++ b/static/main.js
@@ -432,6 +432,7 @@ const End = {
         showConnectionState(),
         m('h2', {}, 'C\'est la fin'),
         m('a', { className: 'button', href: '#', onclick: () => {
+            send({ tag: 'LeaveRoom' })
             m.route.set('/home')
         } }, 'Retourner à l\'accueil'),
         name == players[0].username ? m('a', { className: 'button', href: '#', onclick: () => {

--- a/static/main.js
+++ b/static/main.js
@@ -160,7 +160,7 @@ const registerSocketMessages = (socket) => socket.addEventListener('message', ev
             localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_USERNAME, name)
             localStorage.setItem(LOCALSTORAGE_CURRENT_GAME_AVATAR, avatar)
             players = data.players
-            questionCounter = data.question_counter
+            questionCounter = data.step
             m.route.set('/lobby')
             break
         case 'RoomUpdate':
@@ -436,10 +436,7 @@ const End = {
             m.route.set('/home')
         } }, 'Retourner à l\'accueil'),
         name == players[0].username ? m('a', { className: 'button', href: '#', onclick: () => {
-            send({
-                tag: 'StartGame',
-                code: game
-            })
+            send({ tag: 'StartRound' })
         } }, 'Refaire une partie avec les mêmes personnes') : null
     ])
 }


### PR DESCRIPTION
This PR uses a new version of `ws-hotel` that clarifies the concept of "room". Rooms are no longer manipulated as "rooms" but as `RoomRef`s and `RoomRefWeak`s. By rearranging a bit of code, it is now not only possible, but quite easy to drop rooms with no-one in them.

fixes #12

### Toolchain change
Requires nightly because ws-hotel uses [`arc_new_cyclic`](https://github.com/rust-lang/rust/issues/75861).

### Architectural change
`CreateRoom` was merged into `JoinRoom`, whose `code` field is now an option. This means that a room is implicitly created when trying to join one without specifying a code.

I'm guessing that it was planned that `CreateRoom` could contain admin-specified rules due to [a TODO](https://github.com/WartaPoirier-corp/warta-juge-tes-potes/blob/0cd96374f10b888d37f8bbfd6f61bd943a999d59/src/main.rs#L111). Here's how it could be done:
  * Create a new enum (it could be named `Target`, `RoomTarget`, `RoomId`...) with two variants: `Code(String)` and `New { ... rules ... }`
  * Replace the `code: Option<String>` variant with `target: RoomTarget` or whatever the name is
  * The actual implementation will greatly depend on the amount of rules and their scope but it should be straightforward.

### Remaining stuff
  - [x] Relocate clients to the lobby when a game is finished
  - [ ] _:grey_question: Implement the "restart" button if that's not too out-of-scope_